### PR TITLE
compact heirarchy

### DIFF
--- a/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
@@ -9,8 +9,6 @@ import android.graphics.Rect
 import android.net.Uri
 import android.os.Bundle
 import android.view.accessibility.AccessibilityNodeInfo
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.json.JSONObject
 import xyz.block.gosling.GoslingApplication
 import xyz.block.gosling.OverlayService
@@ -81,83 +79,81 @@ object ToolHandler {
         return gestureResult
     }
 
-    private fun serializeNodeHierarchy(node: AccessibilityNodeInfo): NodeInfo {
-        try {
-            val bounds = Rect().also { node.getBoundsInScreen(it) }
-
-            return NodeInfo(
-                className = node.className?.toString(),
-                packageName = node.packageName?.toString(),
-                text = node.text?.toString()?.takeIf { it.isNotEmpty() },
-                contentDesc = node.contentDescription?.toString()?.takeIf { it.isNotEmpty() },
-                resourceId = node.viewIdResourceName?.takeIf { it.isNotEmpty() },
-                bounds = NodeBounds(
-                    left = bounds.left,
-                    top = bounds.top,
-                    right = bounds.right,
-                    bottom = bounds.bottom
-                ),
-                clickable = if (node.isClickable) true else null,
-                focusable = if (node.isFocusable) true else null,
-                scrollable = if (node.isScrollable) true else null,
-                editable = if (node.isEditable) true else null,
-                enabled = if (!node.isEnabled) false else null,
-                children = if (node.childCount > 0) {
-                    (0 until node.childCount).mapNotNull { i ->
-                        node.getChild(i)?.let { childNode ->
-                            try {
-                                serializeNodeHierarchy(childNode)
-                            } catch (e: Exception) {
-                                NodeInfo(
-                                    error = "Failed to serialize child node: ${e.message}",
-                                    bounds = NodeBounds(0, 0, 0, 0)
-                                )
-                            }
-                        }
-                    }
-                } else null
-            )
-        } catch (e: Exception) {
-            return NodeInfo(
-                error = "Failed to serialize node: ${e.message}",
-                bounds = NodeBounds(0, 0, 0, 0)
-            )
-        }
-    }
-
     @Tool(
         name = "getUiHierarchy",
-        description = "Get the current UI hierarchy as a JSON string. " +
-                "This shows all UI elements, their properties, and locations on screen. " +
-                "clickable, focusable, scrollable, and editable properties are only mentioned " +
-                "when true, enabled only when false.",
+        description = "Get the current UI hierarchy in a compact format. " +
+                "Shows UI elements with their properties and locations on screen in a hierarchical structure. " +
+                "Only includes relevant properties (clickable, focusable, etc. when true; enabled when false).",
         parameters = [],
         requiresAccessibility = true
     )
     fun getUiHierarchy(accessibilityService: AccessibilityService, args: JSONObject): String {
-        val json = Json {
-            prettyPrint = false
-            ignoreUnknownKeys = true
-            encodeDefaults = false
-        }
-
         return try {
-            val activeWindow =
-                accessibilityService.rootInActiveWindow ?: return json.encodeToString(
-                    UiHierarchy(error = "No active window found")
-                )
+            val activeWindow = accessibilityService.rootInActiveWindow 
+                ?: return "ERROR: No active window found"
 
-            val nodeInfo = serializeNodeHierarchy(activeWindow)
-
-            json.encodeToString(
-                UiHierarchy(
-                    packageName = activeWindow.packageName?.toString(),
-                    className = activeWindow.className?.toString(),
-                    nodes = nodeInfo
-                )
-            )
+            val appInfo = "App: ${activeWindow.packageName}"
+            val hierarchy = buildCompactHierarchy(activeWindow)
+            System.out.println("HERE IT IS\n" + hierarchy);
+            "$appInfo (coordinates are [left, top, right, bottom])\n$hierarchy"
         } catch (e: Exception) {
-            json.encodeToString(UiHierarchy(error = "Failed to get UI hierarchy: ${e.message}"))
+            "ERROR: Failed to get UI hierarchy: ${e.message}"
+        }
+    }
+    
+    private fun buildCompactHierarchy(node: AccessibilityNodeInfo, depth: Int = 0): String {
+        try {
+            val bounds = Rect().also { node.getBoundsInScreen(it) }
+            val indent = "  ".repeat(depth)
+            val attributes = mutableListOf<String>()
+            
+            // Add key attributes in a compact format
+            node.text?.toString()?.takeIf { it.isNotEmpty() }?.let { 
+                attributes.add("text=\"$it\"") 
+            }
+            
+            node.contentDescription?.toString()?.takeIf { it.isNotEmpty() }?.let { 
+                attributes.add("desc=\"$it\"") 
+            }
+            
+            node.viewIdResourceName?.takeIf { it.isNotEmpty() }?.let { 
+                attributes.add("id=\"$it\"") 
+            }
+            
+            // Add interactive properties only when true
+            if (node.isClickable) attributes.add("clickable")
+            if (node.isFocusable) attributes.add("focusable")
+            if (node.isScrollable) attributes.add("scrollable")
+            if (node.isEditable) attributes.add("editable")
+            if (!node.isEnabled) attributes.add("disabled")
+            
+            // Format bounds compactly
+            val boundsStr = "[${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}]"
+            
+            // Build the node line
+            val nodeType = node.className?.toString()?.substringAfterLast('.') ?: "View"
+            val attrStr = if (attributes.isNotEmpty()) " " + attributes.joinToString(" ") else ""
+            val nodeLine = "$indent$nodeType$attrStr $boundsStr"
+            
+            // Process children if any
+            val childrenStr = if (node.childCount > 0) {
+                val childrenLines = mutableListOf<String>()
+                for (i in 0 until node.childCount) {
+                    node.getChild(i)?.let { childNode ->
+                        try {
+                            childrenLines.add(buildCompactHierarchy(childNode, depth + 1))
+                        } catch (e: Exception) {
+                            childrenLines.add("${indent}  ERROR: Failed to serialize child: ${e.message}")
+                        }
+                    }
+                }
+                "\n" + childrenLines.joinToString("\n")
+            } else ""
+            
+            return nodeLine + childrenStr
+            
+        } catch (e: Exception) {
+            return "ERROR: Failed to serialize node: ${e.message}"
         }
     }
 

--- a/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
@@ -81,9 +81,7 @@ object ToolHandler {
 
     @Tool(
         name = "getUiHierarchy",
-        description = "Get the current UI hierarchy in a compact format. " +
-                "Shows UI elements with their properties and locations on screen in a hierarchical structure. " +
-                "Only includes relevant properties (clickable, focusable, etc. when true; enabled when false).",
+        description = "call this to show UI elements with their properties and locations on screen in a hierarchical structure.",
         parameters = [],
         requiresAccessibility = true
     )
@@ -95,7 +93,7 @@ object ToolHandler {
             val appInfo = "App: ${activeWindow.packageName}"
             val hierarchy = buildCompactHierarchy(activeWindow)
             System.out.println("HERE IT IS\n" + hierarchy);
-            "$appInfo (coordinates are [left, top, right, bottom])\n$hierarchy"
+            "$appInfo (coordinates are of form: [x-coordinate of the left edge, y-coordinate of the top edge, x-coordinate of the right edge, y-coordinate of the bottom edge])\n$hierarchy"
         } catch (e: Exception) {
             "ERROR: Failed to get UI hierarchy: ${e.message}"
         }
@@ -130,14 +128,14 @@ object ToolHandler {
             val hasNoAttributes = attributes.isEmpty()
             val hasSingleChild = node.childCount == 1
             
-            // Skip this node if it has no attributes and only one child
             if (hasNoAttributes && hasSingleChild && node.getChild(0) != null) {
-                // Skip this level and directly return the child's hierarchy with the same depth
                 return buildCompactHierarchy(node.getChild(0), depth)
             }
             
-            // Format bounds compactly
-            val boundsStr = "[${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}]"
+            // Format bounds compactly with midpoint
+            val midX = (bounds.left + bounds.right) / 2
+            val midY = (bounds.top + bounds.bottom) / 2
+            val boundsStr = "[${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}] midpoint=($midX,$midY)"
             
             // Build the node line
             val indent = "  ".repeat(depth)

--- a/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
@@ -104,7 +104,6 @@ object ToolHandler {
     private fun buildCompactHierarchy(node: AccessibilityNodeInfo, depth: Int = 0): String {
         try {
             val bounds = Rect().also { node.getBoundsInScreen(it) }
-            val indent = "  ".repeat(depth)
             val attributes = mutableListOf<String>()
             
             // Add key attributes in a compact format
@@ -127,10 +126,21 @@ object ToolHandler {
             if (node.isEditable) attributes.add("editable")
             if (!node.isEnabled) attributes.add("disabled")
             
+            // Check if this is a "meaningless" container that should be skipped
+            val hasNoAttributes = attributes.isEmpty()
+            val hasSingleChild = node.childCount == 1
+            
+            // Skip this node if it has no attributes and only one child
+            if (hasNoAttributes && hasSingleChild && node.getChild(0) != null) {
+                // Skip this level and directly return the child's hierarchy with the same depth
+                return buildCompactHierarchy(node.getChild(0), depth)
+            }
+            
             // Format bounds compactly
             val boundsStr = "[${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}]"
             
             // Build the node line
+            val indent = "  ".repeat(depth)
             val nodeType = node.className?.toString()?.substringAfterLast('.') ?: "View"
             val attrStr = if (attributes.isNotEmpty()) " " + attributes.joinToString(" ") else ""
             val nodeLine = "$indent$nodeType$attrStr $boundsStr"

--- a/benchmarking/benchmark.sh
+++ b/benchmarking/benchmark.sh
@@ -112,6 +112,16 @@ for script in $SCENARIO_SCRIPTS; do
     # Save the script output to the test directory
     echo "$OUTPUT" > "$TEST_DIR/script_output.txt"
 
+    # Poll for session dump files every 2 seconds until they appear
+    echo "Waiting for session to finish..."
+    while true; do
+        FILES=$(adb shell ls /storage/emulated/0/Android/data/xyz.block.gosling/files/session_dumps/ 2>/dev/null)
+        if [ -n "$FILES" ]; then
+            echo "Session dump files found: $FILES"
+            break
+        fi
+        sleep 2
+    done
 
     # Collect diagnostics after test completes
     collect_diagnostics "$TEST_DIR"

--- a/benchmarking/benchmark.sh
+++ b/benchmarking/benchmark.sh
@@ -119,7 +119,7 @@ for script in $SCENARIO_SCRIPTS; do
     # Check if goose binary is available
     if command -v goose &> /dev/null; then
         echo "Running goose analysis..."
-        goose run --text "look in ${TEST_DIR} at the session_dumps, look at last result and consider it with the screenshot.png and window_dump.xml if needed, and conclude if test was successful or not, return 'STATUS:PASS/FAIL, TIME:number of seconds'. Add to analysis.txt in that dir"
+        goose run --text "In ${TEST_DIR} look in the session_dumps dir for a json file, 'total_wall_time' has the time taken, the last json result should conclude if it thinks it did the task (can also look further up for evidence). Consider it with the screenshot.png and window_dump.xml if needed, and conclude if test was successful or not, return 'STATUS:PASS/FAIL, TIME:wall time'. Add to analysis.txt in that dir."
     else
         echo "PLEASE INSTALL GOOSE FOR MORE ANALYSIS OF RESULTS"
     fi

--- a/benchmarking/benchmark_common.sh
+++ b/benchmarking/benchmark_common.sh
@@ -47,14 +47,3 @@ input_and_submit() {
     input_text "$message"
     click_submit
 }
-
-# Function to calculate time difference from START_TIME
-get_elapsed_time() {
-    local end_time=$(date +%s.%N)
-    local time_diff=$(echo "$end_time - $START_TIME" | bc)
-    echo "$time_diff"
-}
-
-#echo "Dumping UI hierarchy..."
-#adb shell uiautomator dump
-#adb pull /sdcard/window_dump.xml

--- a/benchmarking/scenario_beer_garden.sh
+++ b/benchmarking/scenario_beer_garden.sh
@@ -6,5 +6,3 @@ source "$SCRIPT_DIR/benchmark_common.sh"
 
 # Input text and click submit
 input_and_submit "Show me the best beer garden in Berlin in maps"
-
-sleep 30

--- a/benchmarking/scenario_camera_email.sh
+++ b/benchmarking/scenario_camera_email.sh
@@ -9,3 +9,5 @@ input_text "$MESSAGE"
 click_submit
 
 sleep 30
+
+echo "The picture should be in the drafts (but it may just show the mail screen, that is ok)"

--- a/benchmarking/scenario_camera_email.sh
+++ b/benchmarking/scenario_camera_email.sh
@@ -8,6 +8,4 @@ MESSAGE="Take a picture using the camera and attach that to a new email. Save th
 input_text "$MESSAGE"
 click_submit
 
-sleep 30
-
-echo "The picture should be in the drafts (but it may just show the mail screen, that is ok)"
+echo "This will save picture in drafts, doesn't matter what screen shows as long as you can check the ui"

--- a/benchmarking/scenario_contact_add.sh
+++ b/benchmarking/scenario_contact_add.sh
@@ -15,5 +15,3 @@ MESSAGE=${1:-"Add contact named $CONTACT"}
 # Input text and click submit
 input_text "$MESSAGE"
 click_submit
-
-sleep 30

--- a/benchmarking/scenario_flashlight.sh
+++ b/benchmarking/scenario_flashlight.sh
@@ -8,4 +8,4 @@ MESSAGE="Turn on the flash light"
 input_text "$MESSAGE"
 click_submit
 
-sleep 30
+echo "should show the flashlight screen"

--- a/benchmarking/scenario_weather.sh
+++ b/benchmarking/scenario_weather.sh
@@ -7,5 +7,3 @@ MESSAGE="What is the weather like?"
 # Input text and click submit
 input_text "$MESSAGE"
 click_submit
-
-sleep 30


### PR DESCRIPTION
This hopefully increases speed and accuracy by using a more compact plain text format for ui hierarchy vs json 

using benchmark.sh it seems a little quicker and more accurate (but still only small numbers of runs). 

eg

```
 FrameLayout [0,0,1280,2856]
     LinearLayout [0,0,1280,2856]
		FrameLayout [0,0,1280,2856]
			 LinearLayout id="com.google.android.apps.maps:id/action_bar_root" [0,0,1280,2856]
				FrameLayout id="android:id/content" [0,0,1280,2856]
					ViewGroup [0,0,1280,2856]
```

style - with "what is the weather like" is around 13989 chars when first navigating the screen.

old is: 36102 (just characters, not tokens). Likely could be compressed a lot more. 

benchmark:

![image](https://github.com/user-attachments/assets/557af06f-f0f1-4bac-8750-cdec07cded78)


old bench mark: 

![image](https://github.com/user-attachments/assets/44cbc2a3-3b6d-44c3-8e93-64cd859cc9f4)


