### PR TITLE
notification handling preferences start

### DIFF
--- a/app/src/main/java/xyz/block/gosling/AccessibilityService.kt
+++ b/app/src/main/java/xyz/block/gosling/AccessibilityService.kt
@@ -80,8 +80,13 @@ class GoslingAccessibilityService : AccessibilityService() {
         val agent = Agent.getInstance() ?: return
         val parcelableData = event.parcelableData
         if (parcelableData is Notification) {
+
+            val parcel = parcelableData as Notification
             val packageName = event.packageName?.toString() ?: return
             if (packageName == "xyz.block.gosling") return
+
+            System.out.println(parcel)
+
 
             // Create an AgentServiceManager to handle notifications
             val agentServiceManager = xyz.block.gosling.features.agent.AgentServiceManager(this)

--- a/app/src/main/java/xyz/block/gosling/AccessibilityService.kt
+++ b/app/src/main/java/xyz/block/gosling/AccessibilityService.kt
@@ -81,11 +81,8 @@ class GoslingAccessibilityService : AccessibilityService() {
         val parcelableData = event.parcelableData
         if (parcelableData is Notification) {
 
-            val parcel = parcelableData as Notification
             val packageName = event.packageName?.toString() ?: return
             if (packageName == "xyz.block.gosling") return
-
-            System.out.println(parcel)
 
 
             // Create an AgentServiceManager to handle notifications

--- a/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
@@ -409,7 +409,6 @@ class Agent : Service() {
                     
                     // Add handling rules if they exist
                     if (messageHandlingPreferences.isNotEmpty()) {
-                        append("\n\nHandling rules:\n")
                         append(messageHandlingPreferences)
                     }
                 }

--- a/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
@@ -392,15 +392,27 @@ class Agent : Service() {
     ) {
         scope.launch {
             try {
-                val prompt = """
-                    Here's the notification:
-                    App: $packageName
-                    Title: $title
-                    Content: $content
-                    Category: $category
+                // Get message handling preferences from settings
+                val settings = SettingsStore(this@Agent)
+                val messageHandlingPreferences = settings.messageHandlingPreferences
+                
+                val prompt = buildString {
+                    append("""
+                        Here's the notification:
+                        App: $packageName
+                        Title: $title
+                        Content: $content
+                        Category: $category
+                        
+                        Please analyze this notification and take appropriate action if needed.
+                    """.trimIndent())
                     
-                    Please analyze this notification and take appropriate action if needed.
-                """.trimIndent()
+                    // Add handling rules if they exist
+                    if (messageHandlingPreferences.isNotEmpty()) {
+                        append("\n\nHandling rules:\n")
+                        append(messageHandlingPreferences)
+                    }
+                }
 
                 processCommand(
                     prompt,

--- a/app/src/main/java/xyz/block/gosling/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/block/gosling/features/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ fun SettingsScreen(
     var currentModel by remember { mutableStateOf(AiModel.fromIdentifier(llmModel)) }
     var apiKey by remember { mutableStateOf(settingsStore.getApiKey(currentModel.provider)) }
     var shouldProcessNotifications by remember { mutableStateOf(settingsStore.shouldProcessNotifications) }
+    var messageHandlingPreferences by remember { mutableStateOf(settingsStore.messageHandlingPreferences) }
     var showResetDialog by remember { mutableStateOf(false) }
     var expanded by remember { mutableStateOf(false) }
 
@@ -232,6 +233,33 @@ fun SettingsScreen(
                                     settingsStore.shouldProcessNotifications = it
                                 }
                             )
+                        }
+                        
+                        // Message handling preferences text area - only visible when notifications are processed
+                        if (shouldProcessNotifications) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 16.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = "Message handling preferences",
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                OutlinedTextField(
+                                    value = messageHandlingPreferences,
+                                    onValueChange = {
+                                        messageHandlingPreferences = it
+                                        settingsStore.messageHandlingPreferences = it
+                                    },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp),
+                                    minLines = 3,
+                                    maxLines = 5
+                                )
+                            }
                         }
                     } else {
                         Text(

--- a/app/src/main/java/xyz/block/gosling/features/settings/SettingsStore.kt
+++ b/app/src/main/java/xyz/block/gosling/features/settings/SettingsStore.kt
@@ -31,6 +31,7 @@ class SettingsStore(context: Context) {
         private const val KEY_API_KEY_PREFIX = "api_key_"
         private const val KEY_ACCESSIBILITY_ENABLED = "accessibility_enabled"
         private const val KEY_PROCESS_NOTIFICATIONS = "process_notifications"
+        private const val KEY_MESSAGE_HANDLING_PREFERENCES = "message_handling_preferences"
         private val DEFAULT_LLM_MODEL = AiModel.AVAILABLE_MODELS.first().identifier
     }
 
@@ -59,4 +60,8 @@ class SettingsStore(context: Context) {
     var shouldProcessNotifications: Boolean
         get() = prefs.getBoolean(KEY_PROCESS_NOTIFICATIONS, false)
         set(value) = prefs.edit { putBoolean(KEY_PROCESS_NOTIFICATIONS, value) }
+        
+    var messageHandlingPreferences: String
+        get() = prefs.getString(KEY_MESSAGE_HANDLING_PREFERENCES, "") ?: ""
+        set(value) = prefs.edit { putString(KEY_MESSAGE_HANDLING_PREFERENCES, value) }
 } 


### PR DESCRIPTION
Very simply - allow a "goosehints" like thing when notifications are processed. 


![Screenshot 2025-03-11 at 8 58 15 pm](https://github.com/user-attachments/assets/3b09626e-6779-422b-af30-9aa02bb2f910)



In future could also have explicit filters for the following if we want (so it doesn't even try) but do need to think more about locking down or planning/blessing actions and approvals:


```java
    public static final String CATEGORY_ALARM = "alarm";
    public static final String CATEGORY_CALL = "call";
    public static final String CATEGORY_EMAIL = "email";
    public static final String CATEGORY_ERROR = "err";
    public static final String CATEGORY_EVENT = "event";
    public static final String CATEGORY_LOCATION_SHARING = "location_sharing";
    public static final String CATEGORY_MESSAGE = "msg";
    public static final String CATEGORY_MISSED_CALL = "missed_call";
    public static final String CATEGORY_NAVIGATION = "navigation";
    public static final String CATEGORY_PROGRESS = "progress";
    public static final String CATEGORY_PROMO = "promo";
    public static final String CATEGORY_RECOMMENDATION = "recommendation";
    public static final String CATEGORY_REMINDER = "reminder";
    public static final String CATEGORY_SERVICE = "service";
    public static final String CATEGORY_SOCIAL = "social";
    public static final String CATEGORY_STATUS = "status";
    public static final String CATEGORY_STOPWATCH = "stopwatch";
    public static final String CATEGORY_SYSTEM = "sys";
    public static final String CATEGORY_TRANSPORT = "transport";
    public static final String CATEGORY_VOICEMAIL = "voicemail";
    public static final String CATEGORY_WORKOUT = "workout";
```