### PR TITLE
fix: stats map serialization was throwing errors

### DIFF
--- a/app/src/main/java/xyz/block/gosling/features/agent/ApiModels.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/ApiModels.kt
@@ -2,6 +2,7 @@ package xyz.block.gosling.features.agent
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 // Common models
@@ -15,7 +16,7 @@ data class Message(
     @SerialName("tool_calls")
     val toolCalls: List<ToolCall>? = null,
     @SerialName("annotations")
-    val annotations: Map<String, Double>? = null
+    val annotations: JsonElement? = null
 )
 
 @Serializable


### PR DESCRIPTION
I was getting errors like this:
```
Error calling LLM: Unexpected JSON token at offset 356: Expected start of the object '{', but had '[' instead at path: $.choices[0].message.annotations
JSON input: ..... null, "annotations": [] }, "logprobs": .....
```