### PR TITLE
add per app instructions

### DIFF
--- a/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
@@ -184,7 +184,7 @@ class Agent : Service() {
                 |Use a screenshot if necessary to check.
                 |
                 |Some tasks will be one shot, but CRITICALLY some will require multiple steps and iteration and checking if you are done.
-                | for example, adding to a shopping card will require multiple steps, as will planning a trip.
+                | for example, adding to a shopping cart will require multiple steps, as will planning a trip.
                 |
                 |Remember: DO NOT ask the user for help or additional information - you must solve the problem autonomously.
                 """.trimMargin()

--- a/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Agent.kt
@@ -175,13 +175,16 @@ class Agent : Service() {
                 |to finalize rendering.
                 |
                 |When you start an app, make sure the app is in the state you expect it to be in. If it is not, 
-                |try to navigate to the correct state.
+                |try to navigate to the correct state (for example, getting back to the home page or start screen).
                 |
                 |After each tool call and before the next step, write down what you see on the screen that helped 
                 |you resolve this step. Keep iterating until you complete the task or have exhausted all possible approaches.
                 |
                 |When you think you are finished, double check to make sure you are done (sometimes you need to click more to continue).
                 |Use a screenshot if necessary to check.
+                |
+                |Some tasks will be one shot, but CRITICALLY some will require multiple steps and iteration and checking if you are done.
+                | for example, adding to a shopping card will require multiple steps, as will planning a trip.
                 |
                 |Remember: DO NOT ask the user for help or additional information - you must solve the problem autonomously.
                 """.trimMargin()

--- a/app/src/main/java/xyz/block/gosling/features/agent/AppInstructions.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/AppInstructions.kt
@@ -15,6 +15,7 @@ object AppInstructions {
             1. Find a specific location
             2. Get directions between locations
             3. Explore nearby places
+            4. Add stops on the way
         IMPORTANT: don't just search for A to B, but search for separate places, add stops if needed.
                    Map search is not general search. There may be locations user is asking for mixed in with general place (like a vegan restaurant)
         """.trimIndent(),

--- a/app/src/main/java/xyz/block/gosling/features/agent/AppInstructions.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/AppInstructions.kt
@@ -1,0 +1,193 @@
+package xyz.block.gosling.features.agent
+
+/**
+ * Store and retrieve per app instructions.
+ */
+object AppInstructions {
+    /**
+     * Map of package names to their corresponding instructions.
+     * Each instruction is a multiline string providing guidance for the specific app.
+     */
+    private val appInstructionsMap = mapOf(
+        // Maps apps
+        "com.google.android.apps.maps" to """            
+            First think if the user wants to:
+            1. Find a specific location
+            2. Get directions between locations
+            3. Explore nearby places
+        IMPORTANT: don't just search for A to B, but search for separate places, add stops if needed.
+                   Map search is not general search. There may be locations user is asking for mixed in with general place (like a vegan restaurant)
+        """.trimIndent(),
+
+        "com.waze" to """
+            Waze is a community-driven navigation app focused on real-time traffic updates.
+            
+            Key features:
+            - GPS navigation with real-time traffic updates
+            - Community-reported hazards, police, and road closures
+            - Find the cheapest gas stations along your route
+            - Estimated arrival times based on live traffic data
+            - Integration with music apps and calendar appointments
+            
+            When using Waze, help the user:
+            1. Enter a destination (use the search bar)
+            2. Choose the best route based on current conditions
+            3. Report or view road hazards and traffic conditions
+            4. Find gas stations or other stops along the route
+        """.trimIndent(),
+        
+        // Amazon app
+        "com.amazon.mShop.android.shopping" to """
+            Amazon Shopping is an e-commerce app for browsing and purchasing products and resaerching.
+                        
+            When using Amazon:
+            1. Use the search bar to find specific products
+            2. Browse categories by tapping the menu icon
+            3. Check product details thoroughly before adding to cart
+            4. Review the cart before proceeding to checkout
+            5. Select shipping options and payment methods during checkout
+        """.trimIndent(),
+        
+
+        // Ride-sharing (Uber)
+        "com.ubercab" to """
+            Uber is a ride-sharing app that connects riders with drivers.
+            
+            Key features:
+            - Request rides to specific destinations
+            - Choose from different ride options (UberX, Comfort, Black, etc.)
+            - View estimated fare and arrival time before confirming
+            - Track driver's location in real-time
+            - Rate drivers and provide feedback after rides
+            - View ride history and receipts
+            
+            When using Uber:
+            1. Enter destination in the "Where to?" field
+            2. Select the type of ride desired
+            3. Confirm pickup location (adjust if needed)
+            4. Review price estimate and confirm ride
+            5. Track driver's approach and communicate if necessary
+            6. Verify driver and vehicle details before entering
+        """.trimIndent(),
+        
+
+        // Add more package name to instructions mappings as needed
+    )
+
+    /**
+     * Retrieves instructions for a specific app based on its package name.
+     * If no exact match is found, tries to match based on package name patterns.
+     *
+     * @param packageName The package name of the app
+     * @return The instructions as a string, or null if no instructions exist for the package
+     */
+    fun getInstructions(packageName: String): String? {
+        // First try exact match
+        appInstructionsMap[packageName]?.let { return it }
+        
+        // If no exact match, try pattern matching
+        val lowercasePackage = packageName.lowercase()
+        
+        return when {
+            // Maps apps
+            lowercasePackage.contains("map") || 
+            lowercasePackage.contains("navigation") || 
+            lowercasePackage.contains("gps") -> """
+                This appears to be a mapping or navigation app.
+                
+                When using mapping apps:
+                1. First determine if the user wants to find a location or get directions
+                2. Use the search bar to enter addresses or place names
+                3. For directions, enter both starting point and destination
+                4. Look for options to change transportation mode (driving, walking, transit)
+                5. Check for additional features like traffic information or nearby places
+                
+                IMPORTANT: Don't just search for A to B, but search for separate places first.
+                Add stops if needed. Map search is not general search.
+            """.trimIndent()
+            
+            // Shopping apps
+            lowercasePackage.contains("shop") || 
+            lowercasePackage.contains("store") || 
+            lowercasePackage.contains("market") || 
+            lowercasePackage.contains("buy") -> """
+                This appears to be a shopping or e-commerce app.
+                
+                When using shopping apps:
+                1. Use the search bar to find specific products
+                2. Browse categories if available
+                3. Check product details, prices, and reviews before adding to cart
+                4. Review cart contents before checkout
+                5. Look for shipping options and payment methods during checkout
+            """.trimIndent()
+            
+            // Social media apps
+            lowercasePackage.contains("social") || 
+            lowercasePackage.contains("chat") || 
+            lowercasePackage.contains("message") || 
+            lowercasePackage.contains("community") -> """
+                This appears to be a social media or messaging app.
+                This can be used for research or answering a user query                
+            """.trimIndent()
+            
+            // Food delivery apps
+            lowercasePackage.contains("food") || 
+            lowercasePackage.contains("delivery") || 
+            lowercasePackage.contains("order") || 
+            lowercasePackage.contains("restaurant") -> """
+                This appears to be a food delivery or restaurant app.
+                
+                When using food delivery apps:
+                1. Confirm location or delivery address
+                2. Browse restaurants or search for specific cuisines
+                3. View menus and select items
+                4. Customize orders as needed
+                5. Review order before checkout
+                6. Select payment method and complete order
+                7. Track delivery status after ordering
+            """.trimIndent()
+            
+            // Transportation/ride-sharing apps
+            lowercasePackage.contains("ride") || 
+            lowercasePackage.contains("taxi") || 
+            lowercasePackage.contains("transit") || 
+            lowercasePackage.contains("transport") -> """
+                This appears to be a transportation or ride-sharing app.
+                
+                When using transportation apps:
+                1. Enter destination in the search field
+                2. Confirm pickup location
+                3. Review available ride options and prices
+                4. Select preferred option and confirm ride
+                5. Track vehicle approach and verify driver information
+                6. Check for payment options and ride history features
+            """.trimIndent()
+            
+            // Banking/payment apps
+            lowercasePackage.contains("bank") || 
+            lowercasePackage.contains("pay") || 
+            lowercasePackage.contains("finance") || 
+            lowercasePackage.contains("money") -> """
+                This appears to be a banking or payment app.
+                
+                When using banking/payment apps:
+                1. Check for account balance and transaction history
+                2. For sending money: Look for transfer or payment options
+                3. For receiving money: Look for request money features
+                4. Verify recipient information carefully before confirming transactions
+                5. Check for security features like biometric authentication
+                6. Look for bill payment or scheduled payment options if needed
+            """.trimIndent()
+
+            else -> {
+                // finally we will see if there is more general advice
+                val category = IntentAppKinds.getCategoryForPackage(packageName)
+                if (category != null && category.generalUsageInstructions.isNotEmpty()) {
+                    return category.generalUsageInstructions
+                } else {
+                    return null
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/xyz/block/gosling/features/agent/IntentAppKinds.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/IntentAppKinds.kt
@@ -7,7 +7,8 @@ package xyz.block.gosling.features.agent
 data class AppCategory(
     val name: String,
     val description: String,
-    val packageNames: Array<String>
+    val packageNames: Array<String>,
+    val generalUsageInstructions: String
 )
 
 /**
@@ -16,7 +17,13 @@ data class AppCategory(
 object IntentAppKinds {
     val paymentApps = AppCategory(
         name = "payment",
-        description = "Consider these apps when needing to make payment or check funds available. Using screenshots is recommended to help navigate these.",
+        description = "Consider these apps when needing to make payment or check funds available.",
+        generalUsageInstructions = """ 
+            these apps typically will have a balance in user settings.
+            you will need to look at various screens visually to navigate.
+             Using screenshots is recommended to help navigate these.
+        """.trimIndent(),
+
         packageNames = arrayOf(
             "com.google.android.apps.nbu.paisa.user", // Google Pay
             "net.one97.paytm", // Paytm
@@ -73,6 +80,12 @@ object IntentAppKinds {
     val travelBookingApps = AppCategory(
         name = "travel booking",
         description = "consider when booking hotels and other travel accommodations or planning trips",
+        generalUsageInstructions = """
+             Use this as a way to explore and help plan along with other apps.
+             If making a booking, you will need to spend some time iterating to find the right screens and enter information.
+             Check with user before committing a booking.            
+        """.trimIndent(),
+
         packageNames = arrayOf(
             "com.booking", // Booking.com
             "com.expedia.bookings", // Expedia
@@ -89,6 +102,8 @@ object IntentAppKinds {
     val foodOrderingApps = AppCategory(
         name = "food ordering or reservations",
         description = "For ordering delivery of food or restaurant reservations",
+        generalUsageInstructions = "",
+
         packageNames = arrayOf(
             "com.doordash.driverapp", // DoorDash
             "com.ubercab.eats", // Uber Eats
@@ -103,6 +118,14 @@ object IntentAppKinds {
     val ecommerceApps = AppCategory(
         name = "ecommerce and products",
         description = "Consider when doing shopping for products or product research, pricing etc",
+        generalUsageInstructions = """
+            first consider if researching products or looking for specific ones. Usually user will be doing one then the other.
+            ensure you find the search and use it to find products.
+            Do scroll when there are lists screenshot them
+            Consider ratings and reviews if asked by clicking in to items. 
+            Click in to items to get details, don't assume. 
+            When ordering, find an add to checkout button and always add to checkout when asked.            
+        """.trimIndent(),
         packageNames = arrayOf(
             "com.amazon.mShop.android.shopping", // Amazon Shopping
             "com.ebay.mobile", // eBay
@@ -212,6 +235,11 @@ object IntentAppKinds {
     val airlineApps = AppCategory(
         name = "air travel",
         description = "for flights, booking or status",
+        generalUsageInstructions = """
+            Look for how to look up flight prices with routes and dates provided, and investigate.
+            The app will often have a place to book flights as well as separate places to check flight status if asked.
+            These apps are often quite complicated so will need to take multiple screenshots as actions are taken and keep iterating to solve.
+        """.trimIndent(),
         packageNames = arrayOf(
             "com.aa.android", // American Airlines
             "com.delta.mobile.android", // Delta Air Lines
@@ -285,17 +313,15 @@ object IntentAppKinds {
         )
     )
     
-    /**
-     * List of all app categories
-     */
-    val allCategories = listOf(
+
+    private  val allCategories = listOf(
         paymentApps,
         travelBookingApps,
         foodOrderingApps,
         ecommerceApps,
         airlineApps
     )
-    
+
     /**
      * Maps a package name to its category
      */

--- a/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
@@ -401,7 +401,8 @@ object ToolHandler {
 
         context.startActivity(launchIntent)
         val appInstruction = AppInstructions.getInstructions(packageName)
-        return "Started app: $packageName $appInstruction"
+        val result = "Starting app: $packageName $appInstruction"
+        return result
     }
 
     @Tool(

--- a/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
+++ b/app/src/main/java/xyz/block/gosling/features/agent/Tools.kt
@@ -400,7 +400,8 @@ object ToolHandler {
         )
 
         context.startActivity(launchIntent)
-        return "Started app: $packageName"
+        val appInstruction = AppInstructions.getInstructions(packageName)
+        return "Started app: $packageName $appInstruction"
     }
 
     @Tool(
@@ -516,8 +517,10 @@ object ToolHandler {
         requiresAccessibility = true
     )
     fun enterText(accessibilityService: AccessibilityService, args: JSONObject): String {
+        val currentPackageName = accessibilityService.rootInActiveWindow?.packageName?.toString() ?: "Unknown package"
 
-        var text = args.getString("text")
+
+        val text = args.getString("text")
 
         val targetNode = if (args.has("id")) {
             accessibilityService.rootInActiveWindow?.findAccessibilityNodeInfosByViewId(


### PR DESCRIPTION
this provides specific app instructions with the startApp tool call response. 
This keeps prompt small and fast, but if it knows about specific app it can reply with instructions on how to drive it. 
There are also general intructions in case a category of app is used which there are general instructions for, but not specific ones learned just yet. 

Allows more sophisticated app driving: 

![image](https://github.com/user-attachments/assets/10d19388-10cc-485f-a9ca-b0fef6dd9d51)
