### PR TITLE
reduce events for battery life

### DIFF
--- a/app/src/main/java/xyz/block/gosling/features/accessibility/AccessibilityService.kt
+++ b/app/src/main/java/xyz/block/gosling/features/accessibility/AccessibilityService.kt
@@ -27,10 +27,10 @@ class GoslingAccessibilityService : AccessibilityService() {
         super.onServiceConnected()
         instance = this
 
-        // Set up service info with all capabilities enabled
+        // Set up service info with notification monitoring only
         val info = AccessibilityServiceInfo()
         info.apply {
-            eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+            eventTypes = AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED
             feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
             flags =
                 AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS or AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or AccessibilityServiceInfo.FLAG_REQUEST_TOUCH_EXPLORATION_MODE or AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityEventTypes="typeNotificationStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagDefault|flagIncludeNotImportantViews|flagRequestTouchExplorationMode|flagReportViewIds|flagRetrieveInteractiveWindows"
     android:canPerformGestures="true"


### PR DESCRIPTION
it was only looking for 

```kotlin
    override fun onAccessibilityEvent(event: AccessibilityEvent) {
        if (event.eventType != AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED) return
```

So changed it to only wake on them, which hopefully saves a lot of batter and wasted CPU