### PR TITLE
Make launcher Activity adapted for large screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,6 @@
             android:exported="true"
             android:label="Goose Mobile Launcher"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.Gosling.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Test it on Pixel 9 Fold Emulator, and it occupied full screen.

Before:
<img width="776" height="751" alt="Screenshot From 2025-12-14 17-11-16" src="https://github.com/user-attachments/assets/95a212f7-bbc3-4434-958d-2c50fde29dd8" />

After:
<img width="776" height="751" alt="Screenshot From 2025-12-14 17-11-35" src="https://github.com/user-attachments/assets/11e70655-8687-456a-b4ce-39456e363bda" />
