### PR TITLE
Fix iOS tunnel setup instructions

### DIFF
--- a/goose-ios/Goose/TrialModeInstructionsView.swift
+++ b/goose-ios/Goose/TrialModeInstructionsView.swift
@@ -62,7 +62,7 @@ struct TrialModeInstructionsView: View {
                             number: 2,
                             title: "Enable Tunneling",
                             description:
-                                "Open Goose desktop, go to Settings → App, and turn on the Tunneling option.",
+                                "Open Goose desktop, go to Settings → Session → Mobile App, and start the tunnel.",
                             icon: "network"
                         )
 


### PR DESCRIPTION
## Summary
- Update the iOS trial-mode tunneling instructions to point users to Settings -> Session -> Mobile App.
- Replace the outdated Settings -> App wording so the app matches the current Goose Desktop UI.

## Testing
- `git diff --check`
- `rg -n "Settings → App|Settings → Session → Mobile App|start the tunnel" goose-ios/Goose/TrialModeInstructionsView.swift`

Note: I could not run `xcodebuild` locally because this environment is Windows and does not provide Xcode.

## Related Issues
Fixes aaif-goose/goose#9532